### PR TITLE
[FIX][StoreDetail] 가게 상세페이지 리뷰 삭제 시 드라이브에서 파일 삭제

### DIFF
--- a/src/common/floatingBar/css/floatingbar.module.css
+++ b/src/common/floatingBar/css/floatingbar.module.css
@@ -128,4 +128,4 @@
     width: 34px;
     height: 34px;
   }
-}/*# sourceMappingURL=floatingbar.module.css.map */
+}

--- a/src/common/footer/css/footer.module.css
+++ b/src/common/footer/css/footer.module.css
@@ -191,4 +191,4 @@
     font-size: 5px;
     color: #FFFFFF;
   }
-}/*# sourceMappingURL=footer.module.css.map */
+}

--- a/src/common/footer/css/reset.module.css
+++ b/src/common/footer/css/reset.module.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.module.css.map */
+}

--- a/src/common/header/css/header.css
+++ b/src/common/header/css/header.css
@@ -383,4 +383,4 @@ header .menu-button img {
   header .menu-button {
     display: none;
   }
-}/*# sourceMappingURL=header.css.map */
+}

--- a/src/common/header/css/reset.css
+++ b/src/common/header/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/common/inquiry/css/reset.css
+++ b/src/common/inquiry/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/common/reset/reset.css
+++ b/src/common/reset/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/store/pages/bossNotice/components/BossTotalNotice.js
+++ b/src/store/pages/bossNotice/components/BossTotalNotice.js
@@ -71,7 +71,7 @@ function BossTotalNotice(){
 
     const sendSearchWordHandler = (searchTerm = "") => {
         const term = typeof searchTerm === 'string' ? searchTerm : "";
-        const url = searchTerm.trim() === "" ? '/notice/user' : `/notice/user?searchWord=${searchTerm}`;
+        const url = searchTerm.trim() === "" ? '/notice/boss' : `/notice/boss?searchWord=${searchTerm}`;
 
         fetch(url)
         .then(res => res.json())
@@ -106,40 +106,6 @@ function BossTotalNotice(){
                             setSearchParams({ searchWord }); 
                         }}
                     />
-                    {/* <div id={styles.strNotice}>공지사항</div>
-                    <img id={styles.imgPin} src={pin}/>
-                    <div className={styles.strArea}>
-                        <div id={styles.strCategory}>카테고리</div>
-                        <div id={styles.strTitle}>제목</div>
-                        <div id={styles.strDate}>날짜</div>
-                    </div>
-                    <div className={styles.noticeContainer}>
-                        {currentItems.map((notice, index) => {
-                            let categoryName = "";
-                            switch(notice.categoryNo){
-                                case 1: categoryName = '안내'; break;
-                                case 2: categoryName = '소개'; break;
-                                case 3: categoryName = '가게'; break;
-                            }
-                            return (
-                                <div
-                                    key={index}
-                                    className={styles.notice}
-                                    style={{border : (index + 1) % 6 === 0 ? "none" : ""}}
-                                    onClick={() => navigateToSpecificNotice(notice.noticeNo)}
-                                >
-                                    <span 
-                                        id={styles.categoryName}
-                                        style={{ backgroundColor : notice.categoryNo === 1 ? "#FF8AA3" : notice.categoryNo === 2 ? "#FEDA00" : "#B3E7FF"}}
-                                    >
-                                        {categoryName}
-                                    </span>
-                                    <span id={styles.noticeTitle}>{notice.noticeTitle}</span>
-                                    <span id={styles.noticeDate}>{notice.date}</span>
-                                </div>
-                            );
-                        })}
-                    </div> */}
                     <div id={styles.strNotice}>공지사항</div>
                         <img id={styles.imgPin} src={pin}/>
                         <div className={styles.strArea}>

--- a/src/store/pages/bossNotice/css/bossSpecificNotice.module.css
+++ b/src/store/pages/bossNotice/css/bossSpecificNotice.module.css
@@ -288,4 +288,4 @@ a:active {
   line-height: 160%;
   overflow-y: auto;
   overflow-x: hidden;
-}/*# sourceMappingURL=bossSpecificNotice.module.css.map */
+}

--- a/src/store/pages/bossNotice/css/bossTotalNotice.module.css
+++ b/src/store/pages/bossNotice/css/bossTotalNotice.module.css
@@ -438,4 +438,4 @@ a:active {
 #background #noticeArea .pagination .arrow.disabled {
   visibility: hidden;
   cursor: default;
-}/*# sourceMappingURL=bossTotalNotice.module.css.map */
+}

--- a/src/user/pages/announcement/css/specificNotice.module.css
+++ b/src/user/pages/announcement/css/specificNotice.module.css
@@ -288,4 +288,4 @@ a:active {
   line-height: 160%;
   overflow-y: auto;
   overflow-x: hidden;
-}/*# sourceMappingURL=specificNotice.module.css.map */
+}

--- a/src/user/pages/announcement/css/totalNotice.module.css
+++ b/src/user/pages/announcement/css/totalNotice.module.css
@@ -438,4 +438,4 @@ a:active {
 #background #noticeArea .pagination .arrow.disabled {
   visibility: hidden;
   cursor: default;
-}/*# sourceMappingURL=totalNotice.module.css.map */
+}

--- a/src/user/pages/find/css/reset.css
+++ b/src/user/pages/find/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/user/pages/login/css/reset.css
+++ b/src/user/pages/login/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/user/pages/main/component/Map.css
+++ b/src/user/pages/main/component/Map.css
@@ -214,4 +214,4 @@ div #map {
     left: 26vw;
     top: 60vw;
   }
-}/*# sourceMappingURL=Map.css.map */
+}

--- a/src/user/pages/main/css/main.css
+++ b/src/user/pages/main/css/main.css
@@ -1900,4 +1900,4 @@ div .hidden-input {
     z-index: -9;
     opacity: 0;
   }
-}/*# sourceMappingURL=main.css.map */
+}

--- a/src/user/pages/mypage/css/reset.css
+++ b/src/user/pages/mypage/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/user/pages/reservation/css/kakaoMap.module.css
+++ b/src/user/pages/reservation/css/kakaoMap.module.css
@@ -273,4 +273,4 @@ a:active {
     font-Style: "Regular";
     border: none;
   }
-}/*# sourceMappingURL=kakaoMap.module.css.map */
+}

--- a/src/user/pages/reservation/css/profile.module.css
+++ b/src/user/pages/reservation/css/profile.module.css
@@ -201,4 +201,4 @@ a:active {
     height: 75px;
     border-radius: 15px;
   }
-}/*# sourceMappingURL=profile.module.css.map */
+}

--- a/src/user/pages/reservation/css/representativePhoto.module.css
+++ b/src/user/pages/reservation/css/representativePhoto.module.css
@@ -201,4 +201,4 @@ a:active {
     height: 290px;
     border-radius: 15px;
   }
-}/*# sourceMappingURL=representativePhoto.module.css.map */
+}

--- a/src/user/pages/reservation/css/reservation.module.css
+++ b/src/user/pages/reservation/css/reservation.module.css
@@ -11,4 +11,4 @@
   .reservation {
     height: 1080px;
   }
-}/*# sourceMappingURL=reservation.module.css.map */
+}

--- a/src/user/pages/reservation/css/reservationInfo.module.css
+++ b/src/user/pages/reservation/css/reservationInfo.module.css
@@ -411,4 +411,4 @@ a:active {
     font-size: 18px;
     margin-left: 15px;
   }
-}/*# sourceMappingURL=reservationInfo.module.css.map */
+}

--- a/src/user/pages/reservation/css/termsOfUse.module.css
+++ b/src/user/pages/reservation/css/termsOfUse.module.css
@@ -566,4 +566,4 @@ a:active {
     color: #232323;
     cursor: pointer;
   }
-}/*# sourceMappingURL=termsOfUse.module.css.map */
+}

--- a/src/user/pages/search/css/search.module.css
+++ b/src/user/pages/search/css/search.module.css
@@ -957,4 +957,4 @@ a:active {
     line-height: 150%;
     color: #232323;
   }
-}/*# sourceMappingURL=search.module.css.map */
+}

--- a/src/user/pages/signup/css/reset.css
+++ b/src/user/pages/signup/css/reset.css
@@ -172,4 +172,4 @@ a:active {
   src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/2410-2@1.0/Mungyeong-Gamhong-Apple.woff2") format("woff2");
   font-weight: normal;
   font-style: normal;
-}/*# sourceMappingURL=reset.css.map */
+}

--- a/src/user/pages/storedetail/components/CreateReview.js
+++ b/src/user/pages/storedetail/components/CreateReview.js
@@ -83,12 +83,11 @@ function CreateReview(){
      const setFileInfo = (file) => {
         const {type, name} = file;
         const isImage = type.includes('image');
+        const isJpgOrPng = type === 'image/jpeg' || type === 'image/png';
         const size = (file.size / (1024 * 1024)).toFixed(2) + 'mb';
         const updatedInfo = {name, size, type, file, isImage}
 
-        //console.log('updatedInfo : ' , updatedInfo);
-
-        if(!isImage){
+        if(!isJpgOrPng){
            alert("이미지 파일만 업로드 가능합니다.") // name, size, type 정보를 uploadedInfo에 저장
             return;
         }

--- a/src/user/pages/storedetail/css/banner.module.css
+++ b/src/user/pages/storedetail/css/banner.module.css
@@ -68,4 +68,4 @@
     height: 100%;
     object-fit: cover;
   }
-}/*# sourceMappingURL=banner.module.css.map */
+}

--- a/src/user/pages/storedetail/css/createReview.module.css
+++ b/src/user/pages/storedetail/css/createReview.module.css
@@ -798,4 +798,4 @@ a:active {
     color: #232323;
     cursor: pointer;
   }
-}/*# sourceMappingURL=createReview.module.css.map */
+}

--- a/src/user/pages/storedetail/css/kakaoMap.module.css
+++ b/src/user/pages/storedetail/css/kakaoMap.module.css
@@ -268,4 +268,4 @@ a:active {
     font-Style: "Regular";
     border: none;
   }
-}/*# sourceMappingURL=kakaoMap.module.css.map */
+}

--- a/src/user/pages/storedetail/css/menu.module.css
+++ b/src/user/pages/storedetail/css/menu.module.css
@@ -211,4 +211,4 @@ a:active {
     top: 260px;
     border-radius: 0;
   }
-}/*# sourceMappingURL=menu.module.css.map */
+}

--- a/src/user/pages/storedetail/css/profile.module.css
+++ b/src/user/pages/storedetail/css/profile.module.css
@@ -35,4 +35,4 @@
     object-fit: cover;
     border-radius: 35px;
   }
-}/*# sourceMappingURL=profile.module.css.map */
+}

--- a/src/user/pages/storedetail/css/reservation.module.css
+++ b/src/user/pages/storedetail/css/reservation.module.css
@@ -923,4 +923,4 @@ a:active {
     top: 1218px;
     width: 458px;
   }
-}/*# sourceMappingURL=reservation.module.css.map */
+}

--- a/src/user/pages/storedetail/css/review.module.css
+++ b/src/user/pages/storedetail/css/review.module.css
@@ -911,4 +911,4 @@ a:active {
     margin-top: 20px;
     border-radius: 15px;
   }
-}/*# sourceMappingURL=review.module.css.map */
+}

--- a/src/user/pages/storedetail/css/storedetail.module.css
+++ b/src/user/pages/storedetail/css/storedetail.module.css
@@ -634,4 +634,4 @@ a:active {
     width: 458px;
     background: #D9D9D9;
   }
-}/*# sourceMappingURL=storedetail.module.css.map */
+}


### PR DESCRIPTION
## 기능 설명 (필수) 😊
> 가게 상세페이지 리뷰 삭제 시 드라이브에서 파일 삭제
<br/>

## 관련 이슈번호 (필수) ✅
#306 
<br/>

## 다른 리뷰어들이 참고해야할 사항을 적어주세요. (선택) 💬
> 가게 상세페이지 리뷰 삭제 시 드라이브에서 파일 삭제 구현했습니다. 그리고 파일 형식을 png로만 했는데 jpg, png 둘 다 가능하게 수정했습니다. 단 이미지 저장 안했을 때 불러오는 기본 리뷰 이미지는 삭제안되게 구현했습니다.
<br/>

## 기능 관련한 이미지 작성바랍니다. (선택) 🖼

![image](https://github.com/user-attachments/assets/20a33d5d-458f-49aa-84d5-1b6bcbaf8b71)

![image](https://github.com/user-attachments/assets/265514da-3791-468f-acfb-db2f8514c377)

![image](https://github.com/user-attachments/assets/94b2cac6-42c2-45f5-8643-663d238dc10c)

